### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To use DBMapSelectorViewController in your project you should perform the follow
 ```objc
 ...
 // (1)
-#import "DBMapSelectorManager.h"
+# import "DBMapSelectorManager.h"
 
 @interface ViewController () <DBMapSelectorManagerDelegate>
 @property (nonatomic, strong) DBMapSelectorManager *mapSelectorManager;
@@ -153,7 +153,7 @@ Denis Bogatyrev (maintainer)
 - https://github.com/d0ping
 - denis.bogatyrev@gmail.com
 
-##License
+## License
 
 DBMapSelectorViewController - Copyright (c) 2015 Denis Bogatyrev
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To use DBMapSelectorViewController in your project you should perform the follow
 ```objc
 ...
 // (1)
-# import "DBMapSelectorManager.h"
+#import "DBMapSelectorManager.h"
 
 @interface ViewController () <DBMapSelectorManagerDelegate>
 @property (nonatomic, strong) DBMapSelectorManager *mapSelectorManager;


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
